### PR TITLE
Fixed the README.md, added clarification regarding installing Docker Compose V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ You can control who has access to a Sync Server by editing its `allowed-users.tx
 1. [Install the Docker Engine](https://docs.docker.com/engine/install/), if you haven't already
 2. [Install Docker Compose](https://docs.docker.com/compose/install/) (We're using Docker Compose V2, so update if you haven't already done so.)
 3. Clone our code
-~~4. Build the container: `docker-compose build map-sync`~~ Docker Compose V2's `run` and `up` will build it for you! Proceed to the next step.
-~~5. Wait~~
+4. ~~Build the container: `docker-compose build map-sync`~~ Docker Compose V2's `run` and `up` will build it for you! Proceed to step 6.
+5. ~~Wait~~
 6. To run the server with interactive prompt: `docker compose run --rm -p 12312:12312 map-sync`
-  - To stop the interactive prompt: hit ctrl-c twice
+    - To stop the interactive prompt: hit ctrl-c twice
 7. To run the server headless: `docker compose up map-sync -d`
-  - To stop the headless server: `docker compose down map-sync`
+    - To stop the headless server: `docker compose down map-sync`
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ You can control who has access to a Sync Server by editing its `allowed-users.tx
 <summary>Docker Install (recommended)</summary>
 <br />
 
-- [Install docker](https://docs.docker.com/get-docker/)
-- clone code
-- Build the container: `docker-compose build map-sync`
-- Wait
-- To run server with interactive prompt: `docker-compose run --rm -p 12312:12312 map-sync`
-  - To stop interactive prompt: hit ctrl-c
-- To run server headless: `docker-compose up map-sync -d`
-  - To stop headless server: `docker-compose down map-sync`
+1. [Install the Docker Engine](https://docs.docker.com/engine/install/), if you haven't already
+2. [Install Docker Compose](https://docs.docker.com/compose/install/) (We're using Docker Compose V2, so update if you haven't already done so.)
+3. Clone our code
+~~4. Build the container: `docker-compose build map-sync`~~ Docker Compose V2's `run` and `up` will build it for you! Proceed to the next step.
+~~5. Wait~~
+6. To run the server with interactive prompt: `docker compose run --rm -p 12312:12312 map-sync`
+  - To stop the interactive prompt: hit ctrl-c twice
+7. To run the server headless: `docker compose up map-sync -d`
+  - To stop the headless server: `docker compose down map-sync`
 </details>
 
 <details>


### PR DESCRIPTION
- Everyone's PR suggestions should be here in this commit now
- I FORGOT THE build: . DIRECTIVE AAAAA
- No such command "docker compose"; replaced with "docker-compose". Also, no need for "docker compose run -it, docker-compose run automatically attaches to the running terminal.
- Fixed the commands and Docker install guide on README.md
