### PR TITLE
*Actually* kick the client

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -172,7 +172,7 @@ export class TcpClient {
 
 	kick(internalReason: string) {
 		this.log(`Kicking:`, internalReason)
-		this.socket.end()
+		this.socket.destroy()
 	}
 
 	async send(pkt: ServerPacket) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52572989/171971468-6356cbe2-f0ad-4894-a67f-a2ce63df5b07.png)

**versus**

![image](https://user-images.githubusercontent.com/52572989/171971492-5055a5e4-2e7d-4987-a44c-f9f2b15dd38b.png)

----

Context, I've been connecting to my localhost map-sync server with ncat and sending a bunch of junk data and noticing the server *saying* it was kicking me but not actually kicking me.