### PR TITLE
No longer throw when the client isn't whitelisted

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -29,7 +29,7 @@ export class Main {
 					`Rejected unwhitelisted user ${client.mcName} (${client.uuid})`,
 				)
 				client.kick(`Not whitelisted`)
-				throw new Error(`Not whitelisted`)
+				return;
 			}
 		}
 


### PR DESCRIPTION
The whitelist feature was added (bb7b478a5feb1d51897e9e3e7bed24eda231c5f9) to throw when the server authenticates a client and discovers they're not whitelisted... not sure why... perhaps a debugging thing? But it's not necessary, particularly given #40, so this PR replaces the throw with a return.