### PR TITLE
Change Prettier to require semicolons

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,6 @@
 		"tabWidth": 2,
 		"trailingComma": "all",
 		"singleQuote": true,
-		"semi": false
+		"semi": true
 	}
 }


### PR DESCRIPTION
I was asked to run Prettier on my PR (#45), which is fine, but one of the effects was the removal of every semicolon in the code... why? Prettier's documentation explains that the `false` setting *will* add semicolons if not doing so will cause ASI failures, which results in odd looking code like:
```js
if (shouldAddLines) {
  ;[-1, 1].forEach(delta => addLine(delta * 20))
}
```
Why? Why is *this* preferable? Remember that Prettier is being applied to the developer-facing TypeScript code, not the transpiled Javascript code. Why should Prettier be making code look more confusing to those who don't necessarily understand Javascript's ASI rules? Why not just require semicolons and never have to think about ASI ever again?