### PR TITLE
Use Kyori Blossom to fix version filtering

### DIFF
--- a/mod/common/build.gradle
+++ b/mod/common/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+	// https://github.com/KyoriPowered/blossom/releases
+	id("net.kyori.blossom") version "1.3.1"
+}
+
 dependencies {
 	// We depend on fabric loader here to use the fabric @Environment annotations and get the mixin dependencies
 	// Do NOT use other classes from fabric loader
@@ -13,6 +18,16 @@ dependencies {
 architectury {
 	injectInjectables = false
 	common()
+}
+
+tasks {
+	blossom {
+		replaceToken (
+				"%VERSION%",
+				project.version,
+				"src/main/java/gjum/minecraft/mapsync/common/MapSyncMod.java"
+		)
+	}
 }
 
 publishing {

--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/MapSyncMod.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/MapSyncMod.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import static gjum.minecraft.mapsync.common.Cartography.chunkTileFromLevel;
 
 public abstract class MapSyncMod {
-	public static final String VERSION = "${version}";
+	public static final String VERSION = "%VERSION%";
 
 	private static final Minecraft mc = Minecraft.getInstance();
 


### PR DESCRIPTION
From what I remember from Discord discussions, when 3ffcf96282b86222899c9e1677b23b5612d883aa was pushed, the presumption was that the token `${version}` would be filtered by the `processResources` task, but this is not the case, which means that, after [v1.0.1](https://github.com/CivPlatform/map-sync/releases/tag/v1.0.1), each mod has been declaring itself in its handshake packet as `${version}-fabric` or `${version}-forge`. This issue hasn't mattered much since the server doesn't do anything with the information, but nonetheless this PR fixes this issue.