### PR TITLE
Optimise CatchupChunk and related uses

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -96,7 +96,6 @@ export async function getChunkTimestamps(dimension: string, regions: Pos2D[]) {
 			db
 				.selectFrom('player_chunk')
 				.select([
-					'world',
 					(eb) =>
 						kysely.sql<string>`(cast(floor(${eb.ref(
 							'chunk_x',
@@ -107,11 +106,11 @@ export async function getChunkTimestamps(dimension: string, regions: Pos2D[]) {
 					'chunk_z as z',
 					(eb) => eb.fn.max('ts').as('timestamp'),
 				])
-				.groupBy(['world', 'x', 'z']),
+				.where('world', '=', dimension)
+				.groupBy(['x', 'z']),
 		)
 		.selectFrom('regions')
-		.select(['world', 'x as chunkX', 'z as chunkZ', 'timestamp'])
-		.where('world', '=', dimension)
+		.select(['x as chunkX', 'z as chunkZ', 'timestamp'])
 		.where(
 			'region',
 			'in',

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -110,7 +110,7 @@ export async function getChunkTimestamps(dimension: string, regions: Pos2D[]) {
 				.groupBy(['world', 'x', 'z']),
 		)
 		.selectFrom('regions')
-		.select(['world', 'x as chunk_x', 'z as chunk_z', 'timestamp as ts'])
+		.select(['world', 'x as chunkX', 'z as chunkZ', 'timestamp'])
 		.where('world', '=', dimension)
 		.where(
 			'region',

--- a/server/src/model.ts
+++ b/server/src/model.ts
@@ -5,10 +5,9 @@ export interface CatchupRegion {
 }
 
 export interface CatchupChunk {
-	world: string
-	chunk_x: number
-	chunk_z: number
-	ts: number
+	readonly chunkX: number
+	readonly chunkZ: number
+	readonly timestamp: number
 }
 
 export interface Pos2D {

--- a/server/src/protocol/CatchupPacket.ts
+++ b/server/src/protocol/CatchupPacket.ts
@@ -3,18 +3,20 @@ import { BufWriter } from './BufWriter'
 
 export interface CatchupPacket {
 	type: 'Catchup'
+	world: string
 	chunks: CatchupChunk[]
 }
 
 export namespace CatchupPacket {
 	export function encode(pkt: CatchupPacket, writer: BufWriter) {
-		if (!pkt.chunks[0]) throw new Error(`Catchup chunks must not be empty`)
-		writer.writeString(pkt.chunks[0].world)
+		if (pkt.chunks.length < 1)
+			throw new Error(`Catchup chunks must not be empty`)
+		writer.writeString(pkt.world)
 		writer.writeUInt32(pkt.chunks.length)
 		for (const row of pkt.chunks) {
-			writer.writeInt32(row.chunk_x)
-			writer.writeInt32(row.chunk_z)
-			writer.writeUInt64(row.ts)
+			writer.writeInt32(row.chunkX)
+			writer.writeInt32(row.chunkZ)
+			writer.writeUInt64(row.timestamp)
 		}
 	}
 }

--- a/server/src/protocol/CatchupRequestPacket.ts
+++ b/server/src/protocol/CatchupRequestPacket.ts
@@ -3,22 +3,21 @@ import { BufReader } from './BufReader'
 
 export interface CatchupRequestPacket {
 	type: 'CatchupRequest'
+	world: string
 	chunks: CatchupChunk[]
 }
 
 export namespace CatchupRequestPacket {
 	export function decode(reader: BufReader): CatchupRequestPacket {
 		const world = reader.readString()
-		const numChunks = reader.readUInt32()
-		const chunks: CatchupChunk[] = []
-		for (let i = 0; i < numChunks; i++) {
-			chunks.push({
-				world,
-				chunk_x: reader.readInt32(),
-				chunk_z: reader.readInt32(),
-				ts: reader.readUInt64(),
-			})
+		const chunks: CatchupChunk[] = new Array(reader.readUInt32())
+		for (let i = 0; i < chunks.length; i++) {
+			chunks[i] = {
+				chunkX: reader.readInt32(),
+				chunkZ: reader.readInt32(),
+				timestamp: reader.readUInt64(),
+			}
 		}
-		return { type: 'CatchupRequest', chunks }
+		return { type: 'CatchupRequest', world, chunks }
 	}
 }


### PR DESCRIPTION
There's no need to have each chunk contain a copy of the world string when it can be stored once on the packet itself.

Also updated the CatchupRequestPacket so that there's no array expansion happening.