### PR TITLE
Stop length-prefixing hashes

### DIFF
--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/data/ChunkTile.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/data/ChunkTile.java
@@ -1,6 +1,8 @@
 package gjum.minecraft.mapsync.common.data;
 
 import gjum.minecraft.mapsync.common.net.Packet;
+import gjum.minecraft.mapsync.common.utils.Arguments;
+import gjum.minecraft.mapsync.common.utils.MagicValues;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -18,6 +20,11 @@ public record ChunkTile(
 		byte[] dataHash,
 		BlockColumn[] columns
 ) {
+	public ChunkTile {
+		Arguments.checkNotNull("dataHash", dataHash);
+		Arguments.checkLength("dataHash", dataHash.length, MagicValues.SHA1_HASH_LENGTH);
+	}
+
 	public ChunkPos chunkPos() {
 		return new ChunkPos(x, z);
 	}
@@ -36,7 +43,6 @@ public record ChunkTile(
 		buf.writeInt(z);
 		buf.writeLong(timestamp);
 		buf.writeShort(dataVersion);
-		buf.writeInt(dataHash.length); // TODO could be Short as hash length is known to be small
 		buf.writeBytes(dataHash);
 	}
 
@@ -53,8 +59,7 @@ public record ChunkTile(
 		int z = buf.readInt();
 		long timestamp = buf.readLong();
 		int dataVersion = buf.readUnsignedShort();
-		byte[] hash = new byte[buf.readInt()];
-		buf.readBytes(hash);
+		byte[] hash = Packet.readByteArrayOfSize(buf, MagicValues.SHA1_HASH_LENGTH);
 		var columns = new BlockColumn[256];
 		for (int i = 0; i < 256; i++) {
 			columns[i] = BlockColumn.fromBuf(buf);

--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/net/Packet.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/net/Packet.java
@@ -13,14 +13,21 @@ public interface Packet {
 		throw new NotImplementedException();
 	}
 
+	static byte @NotNull [] readByteArrayOfSize(
+			final @NotNull ByteBuf in,
+			final int size
+	) {
+		final var bytes = new byte[size];
+		if (size > 0) {
+			in.readBytes(bytes);
+		}
+		return bytes;
+	}
+
 	static byte @NotNull [] readIntLengthByteArray(
 			final @NotNull ByteBuf in
 	) {
-		final var array = new byte[in.readInt()];
-		if (array.length > 0) {
-			in.readBytes(array);
-		}
-		return array;
+		return readByteArrayOfSize(in, in.readInt());
 	}
 
 	static void writeIntLengthByteArray(

--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/utils/Arguments.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/utils/Arguments.java
@@ -1,0 +1,24 @@
+package gjum.minecraft.mapsync.common.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class Arguments {
+    public static void checkNotNull(
+            final @NotNull String name,
+            final Object value
+    ) {
+        if (value == null) {
+            throw new IllegalArgumentException("'" + name + "' is null!");
+        }
+    }
+
+    public static void checkLength(
+            final @NotNull String name,
+            final int currentLength,
+            final int requiredLength
+    ) {
+        if (currentLength != requiredLength) {
+            throw new IllegalArgumentException("'" + name + "' has length " + currentLength + " when it must be " + requiredLength);
+        }
+    }
+}

--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/utils/MagicValues.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/utils/MagicValues.java
@@ -1,0 +1,7 @@
+package gjum.minecraft.mapsync.common.utils;
+
+public final class MagicValues {
+    // SHA1 produces 160-bit (20-byte) hashes
+    // https://en.wikipedia.org/wiki/SHA-1
+    public static final int SHA1_HASH_LENGTH = 20;
+}

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -2,3 +2,7 @@ export const SUPPORTED_VERSIONS = new Set([
 	'2.0.1-1.18.2+fabric',
 	'2.0.1-1.18.2+forge',
 ])
+
+// SHA1 produces 160-bit (20-byte) hashes
+// https://en.wikipedia.org/wiki/SHA-1
+export const SHA1_HASH_LENGTH = 20

--- a/server/src/protocol/ChunkTilePacket.ts
+++ b/server/src/protocol/ChunkTilePacket.ts
@@ -1,5 +1,6 @@
 import { BufReader } from './BufReader'
 import { BufWriter } from './BufWriter'
+import { SHA1_HASH_LENGTH } from '../constants'
 
 export interface ChunkTilePacket {
 	type: 'ChunkTile'
@@ -20,7 +21,7 @@ export namespace ChunkTilePacket {
 			ts: reader.readUInt64(),
 			data: {
 				version: reader.readUInt16(),
-				hash: reader.readBufWithLen(),
+				hash: reader.readBufLen(SHA1_HASH_LENGTH),
 				data: reader.readRemainder(),
 			},
 		}
@@ -32,7 +33,7 @@ export namespace ChunkTilePacket {
 		writer.writeInt32(pkt.chunk_z)
 		writer.writeUInt64(pkt.ts)
 		writer.writeUInt16(pkt.data.version)
-		writer.writeBufWithLen(pkt.data.hash)
+		writer.writeBufRaw(pkt.data.hash)
 		writer.writeBufRaw(pkt.data.data) // XXX do we need to prefix with length?
 	}
 }


### PR DESCRIPTION
This can be applied to other things too, of course, but didn't want to de-length-prefix everything at once.