### PR TITLE
Disable authentication client-side if in dev mode

### DIFF
--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/MapSyncMod.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/MapSyncMod.java
@@ -68,7 +68,7 @@ public abstract class MapSyncMod {
 	 */
 	public abstract String getVersion();
 
-	protected abstract boolean isDevMode();
+	public abstract boolean isDevMode();
 
 	public abstract void registerKeyBinding(KeyMapping mapping);
 

--- a/mod/common/src/main/java/gjum/minecraft/mapsync/common/net/SyncClient.java
+++ b/mod/common/src/main/java/gjum/minecraft/mapsync/common/net/SyncClient.java
@@ -1,6 +1,7 @@
 package gjum.minecraft.mapsync.common.net;
 
 import com.mojang.authlib.exceptions.AuthenticationException;
+import gjum.minecraft.mapsync.common.MapSyncMod;
 import gjum.minecraft.mapsync.common.data.ChunkTile;
 import gjum.minecraft.mapsync.common.net.encryption.EncryptionDecoder;
 import gjum.minecraft.mapsync.common.net.encryption.EncryptionEncoder;
@@ -245,16 +246,21 @@ public class SyncClient {
 			byte[] sharedSecret = new byte[16];
 			ThreadLocalRandom.current().nextBytes(sharedSecret);
 
-			// note that this is different from minecraft (we get no negative hashes)
-			final String shaHex = HexFormat.of().formatHex(Hasher.sha1()
-					.update(sharedSecret)
-					.update(packet.publicKey.getEncoded())
-					.generateHash()
-			);
+			if (!MapSyncMod.getMod().isDevMode()) {
+				// note that this is different from minecraft (we get no negative hashes)
+				final String shaHex = HexFormat.of().formatHex(Hasher.sha1()
+						.update(sharedSecret)
+						.update(packet.publicKey.getEncoded())
+						.generateHash()
+				);
 
-			User session = Minecraft.getInstance().getUser();
-			Minecraft.getInstance().getMinecraftSessionService().joinServer(
-					session.getGameProfile(), session.getAccessToken(), shaHex);
+				final User session = Minecraft.getInstance().getUser();
+				Minecraft.getInstance().getMinecraftSessionService().joinServer(
+						session.getGameProfile(),
+						session.getAccessToken(),
+						shaHex
+				);
+			}
 
 			try {
 				ctx.channel().writeAndFlush(new ServerboundEncryptionResponsePacket(

--- a/mod/fabric/src/main/java/gjum/minecraft/mapsync/fabric/FabricMapSyncMod.java
+++ b/mod/fabric/src/main/java/gjum/minecraft/mapsync/fabric/FabricMapSyncMod.java
@@ -26,7 +26,7 @@ public class FabricMapSyncMod extends MapSyncMod implements ClientModInitializer
 	}
 
 	@Override
-	protected boolean isDevMode() {
+	public boolean isDevMode() {
 		return FabricLoader.getInstance().isDevelopmentEnvironment();
 	}
 

--- a/mod/forge/src/main/java/gjum/minecraft/mapsync/forge/ForgeMapSyncMod.java
+++ b/mod/forge/src/main/java/gjum/minecraft/mapsync/forge/ForgeMapSyncMod.java
@@ -24,7 +24,7 @@ public class ForgeMapSyncMod extends MapSyncMod {
 	}
 
 	@Override
-	protected boolean isDevMode() {
+	public boolean isDevMode() {
 		return !FMLLoader.isProduction();
 	}
 


### PR DESCRIPTION
This takes advantage of the `isDevMode` method added in #82 to prevent the client from attempting to authenticate with Mojang since a development environment, by its nature, doesn't have an 'online' account, so the attempt will throw, which the protocol has no way to recover from. The server will still need to have the `DISABLE_AUTH` environment variable set, otherwise the server will forcibly disconnect the client for not being authenticated with Mojang.