### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-mod.yml
+++ b/.github/workflows/build-mod.yml
@@ -1,4 +1,4 @@
-name: Build Mod
+name: "Build Mods"
 
 on:
   push:
@@ -7,39 +7,20 @@ on:
   pull_request:
     paths:
       - "mod/**/*"
+  workflow_call:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - uses: "actions/checkout@v4"
+
+      - name: "Setting up JDK 17"
+        uses: "actions/setup-java@v4"
         with:
           java-version: "17"
           distribution: "adopt"
-      - run: ./gradlew build
-        working-directory: ./mod
 
-      - name: Upload Forge Build
-        uses: actions/upload-artifact@v3
-        with:
-          name: Forge
-          path: mod/dist/*-forge.jar
-
-      - name: Upload Fabric Build
-        uses: actions/upload-artifact@v3
-        with:
-          name: Fabric
-          path: mod/dist/*-fabric.jar
-
-      - name: Release Tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
-        with:
-          prerelease: true
-          fail_on_unmatched_files: true
-          files: |
-            mod/dist/*.jar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Building mods"
+        working-directory: "./mod"
+        run: "./gradlew build"

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -1,4 +1,4 @@
-name: Build+Test Server
+name: "Build+Test Server"
 
 on:
   push:
@@ -7,23 +7,32 @@ on:
   pull_request:
     paths:
       - "server/**/*"
+  workflow_call:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ["lts/*", "latest"]
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - name: Use latest Node.js LTS
-        uses: actions/setup-node@v3
+      - uses: "actions/checkout@v4"
+      
+      - name: "Setting up nodejs"
+        uses: "actions/setup-node@v4"
         with:
-          node-version: ${{ matrix.version }}
+          node-version: "24"
           # cache: "yarn"
-      - run: yarn
-        working-directory: ./server
-      - run: yarn build
-        working-directory: ./server
-      - run: yarn test
-        working-directory: ./server
+
+      - name: "Setting up yarn"
+        working-directory: "./server"
+        run: "yarn"
+
+      - name: "Checking types"
+        working-directory: "./server"
+        run: "yarn run check:types"
+
+      - name: "Checking style"
+        working-directory: "./server"
+        run: "yarn run check:style"
+
+      - name: "Testing server"
+        working-directory: "./server"
+        run: "yarn run test"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: "Publishing to release"
+
+on:
+  release:
+    types:
+      - "published"
+
+permissions:
+  contents: "write"
+
+jobs:
+  release-mod:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: "Setting up JDK 17"
+        uses: "actions/setup-java@v4"
+        with:
+          java-version: "17"
+          distribution: "adopt"
+
+      - name: "Building mods"
+        working-directory: "./mod"
+        run: "./gradlew build"
+
+      - name: "Publishing mods"
+        working-directory: "./mod"
+        run: |
+          for file in $(find "dist/" -maxdepth 1 -type f -name "*.jar"); do
+            echo "Uploading $file"
+            gh release upload ${{ github.event.release.tag_name }} "$file" --clobber
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Add a "release-server" at some point via packaging to executable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # base is shared between build/test and deploy
-FROM node:18-alpine AS base
+# See options at: https://hub.docker.com/_/node
+FROM node:24-alpine AS base
 
 WORKDIR /usr/src/app/
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can control who has access to a Sync Server by editing its `allowed-users.tx
 <summary>System Install</summary>
 <br />
 
-- install recent nodejs (~17)
+- install recent nodejs (~24)
 - clone code, `cd server`
 - `npm install`
 - `npm run build` -- this has to be run after every time the code is edited

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,8 @@
     "author": "Gjum",
     "license": "GPL-3.0-only",
     "scripts": {
+        "check:types": "tsc --noEmit --checkJs",
+        "check:style": "prettier --check .",
         "build": "tsc",
         "format": "prettier -w .",
         "test": "true",


### PR DESCRIPTION
This *should* fix the workflows, as requested [here](https://github.com/CivPlatform/map-sync/pull/106#issuecomment-2968254797). The build-* workflows no longer publish a new release. Instead, there's a new release workflow that automatically runs when a new release is made, which builds the mod and uploads the artefacts. This also updates the expected-version of nodejs to v24.