### PR TITLE
Enable KEEPALIVE server side

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,11 +25,16 @@ export class TcpServer {
     });
 
     constructor(readonly handler: ProtocolHandler) {
-        this.server = net.createServer({}, (socket) => {
-            const client = new TcpClient(socket, this, handler);
-            this.clients[client.id] = client;
-            socket.on("close", () => delete this.clients[client.id]);
-        });
+        this.server = net.createServer(
+            {
+                keepAlive: true,
+            },
+            (socket) => {
+                const client = new TcpClient(socket, this, handler);
+                this.clients[client.id] = client;
+                socket.on("close", () => delete this.clients[client.id]);
+            },
+        );
 
         this.server.on("error", (err: Error) => {
             console.error("[TcpServer] Error:", err);


### PR DESCRIPTION
`SO_KEEPALIVE` is [already enabled](https://github.com/CivPlatform/map-sync/blob/ba963925da0c933bebbf06f960004ed4195e40b5/mod/common/src/main/java/gjum/minecraft/mapsync/common/net/SyncClient.java#L112) clientside, which I presume means the client can detect unexpected disconnects, but not the server? Enabling it for the server too *should* resolve #7, but I'm unsure: why would websockets for example need [ping/pong packets](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) if tcp's keepalive already does that?